### PR TITLE
lowercase package name when building index

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn sync(lockfile: &Path,
             build_ar(&mut ar, &pkg, config);
         }
 
-        let name = id.name();
+        let name = id.name().to_lowercase();
         let part = match name.len() {
             1 => format!("1/{}", name),
             2 => format!("2/{}", name),


### PR DESCRIPTION
When cargo looks for the package via index, it seems like it uses lowercased
package name. For example, "Inflector" package will be looked at "index/in/fl/inflector".

However, cargo-local-registry would create index entry at "index/In/fl/Inflector".
This would work fine on a case-insensitive filesystem (developer's Macbook laptop, for example),
but would fail on, for instance, Linux where file system is case-sensitive.